### PR TITLE
RITM1253104

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -98,8 +98,6 @@ primary_navigation:
         url: /law-library/
       - name: OMB Guidance
         url: /resources/omb/
-      - name: FPC SORN Dashboard
-        url: https://sorndashboard.fpc.gov/
       - name: Government-wide SORNs
         url: /resources/SORNs/
       - name: Glossary

--- a/_pages/resources/sorns.md
+++ b/_pages/resources/sorns.md
@@ -13,8 +13,6 @@ header-image: /assets/img/header-image.jpg
 
 <p class="font-sans-sm">This list of SORNs is provided for informational purposes only and may not include every government-wide SORN. Visitors to this website should not rely upon any information provided on this website for the purpose of making decisions related to agency practices and policies.</p>
 
-<p class="font-sans-sm">To search across all Government SORNs access the <a href="https://sorndashboard.fpc.gov/">FPC SORN Dashboard</a>. The FPC SORN dashboard regularly pulls newly published SORNs from the Federal Register, and includes documents from 1994 to the present day.</p>
-
 <p class="font-sans-sm">If you identify a potential error in this list of government-wide SORNs or believe we failed to include a government-wide SORN, please email us at <a href="mailto:privacycouncil@gsa.gov">privacycouncil@gsa.gov</a>.
 
 </p>


### PR DESCRIPTION
**Requirement Description**
Please remove the link to the SORN Dashboard from the top-level "Resources" navigation menu on FPC.gov, as it is no longer active following its closure. We will provide a redirect link in the coming days. 

Additionally, please eliminate the following text from the page at https://www.fpc.gov/resources/SORNs/: “To search across all Government SORNs, access the FPC SORN Dashboard. The FPC SORN Dashboard regularly pulls newly published SORNs from the Federal Register and includes documents from 1994 to the present day.”

This text also refers to the inactive SORN Dashboard. Thank you!

**Validation Link**
https://federalist-61b9594e-083a-41f6-89bb-8b418db4ccf9.sites.pages.cloud.gov/preview/gsa/fpc.gov/feature/RITM1253104/