### PR TITLE
Fix code scanning alert no. 7: Unsafe jQuery plugin

### DIFF
--- a/assets/js/magnific-popup.js
+++ b/assets/js/magnific-popup.js
@@ -506,7 +506,7 @@
                 _mfpTrigger('FirstMarkupParse', markup);
 
                 if(markup) {
-                    mfp.currTemplate[type] = $(markup);
+                    mfp.currTemplate[type] = $.find(markup);
                 } else {
                     // if there is no markup found we just define that template is parsed
                     mfp.currTemplate[type] = true;


### PR DESCRIPTION
Fixes [https://github.com/GSA/fpc.gov/security/code-scanning/7](https://github.com/GSA/fpc.gov/security/code-scanning/7)

To fix the problem, we need to ensure that the `markup` property in the `options` object is properly sanitized before being used to create DOM elements. This can be achieved by using a method that treats the input as plain text rather than HTML, or by explicitly sanitizing the input to remove any potentially harmful content.

The best way to fix this issue without changing existing functionality is to use a method that ensures the `markup` is treated as a CSS selector rather than HTML. This can be done by using `jQuery.find` instead of `jQuery` to interpret the `markup` as a CSS selector.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
