### PR TITLE
Fix code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/slick.js
+++ b/assets/js/slick.js
@@ -18,14 +18,14 @@
 (function (factory) {
     'use strict';
     if (typeof define === 'function' && define.amd) {
-        define(['jquery'], factory);
+        define(['jquery', 'dompurify'], factory);
     } else if (typeof exports !== 'undefined') {
-        module.exports = factory(require('jquery'));
+        module.exports = factory(require('jquery'), require('dompurify'));
     } else {
-        factory(jQuery);
+        factory(jQuery, window.DOMPurify);
     }
 
-}(function ($) {
+}(function ($, DOMPurify) {
     'use strict';
     var Slick = window.Slick || {};
 
@@ -1459,7 +1459,7 @@
             $('img[data-lazy]', imagesScope).each(function () {
 
                 var image = $(this),
-                    imageSource = $(this).attr('data-lazy'),
+                    imageSource = DOMPurify.sanitize($(this).attr('data-lazy')),
                     imageToLoad = document.createElement('img');
 
                 imageToLoad.onload = function () {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "dot-prop": "^5.3.0",
     "jquery": "^3.7.1",
     "netlify-cms": "^2.10.55",
-    "uswds": "^2.14.0"
+    "uswds": "^2.14.0",
+    "dompurify": "^3.2.3"
   },
   "devDependencies": {
     "rimraf": "^3.0.2"
@@ -23,7 +24,7 @@
     "minimist": "1.2.8",
     "remark-parse": ">=10.0.1",
     "mdast-util-to-hast": ">=5.0.0",
-    "trim":">=0.0.3",
+    "trim": ">=0.0.3",
     "tough-cookie": ">=4.1.4",
     "got": ">=11.8.5",
     "trim-newlines": ">=5.0.0",


### PR DESCRIPTION
Fixes [https://github.com/GSA/fpc.gov/security/code-scanning/2](https://github.com/GSA/fpc.gov/security/code-scanning/2)

To fix the problem, we need to ensure that the value of `imageSource` is properly sanitized before it is used to set the `src` attribute of the `img` element. One way to achieve this is by using a library like DOMPurify to sanitize the value. This will ensure that any potentially malicious content is removed before it is used.

We will:
1. Import the DOMPurify library.
2. Sanitize the `imageSource` value before using it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
