### PR TITLE
Fix code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/slick.js
+++ b/assets/js/slick.js
@@ -27,6 +27,7 @@
 
 }(function ($) {
     'use strict';
+    var DOMPurify = require('dompurify');
     var Slick = window.Slick || {};
 
     Slick = (function () {
@@ -1648,7 +1649,7 @@
         if ($imgsToLoad.length) {
 
             image = $imgsToLoad.first();
-            imageSource = image.attr('data-lazy');
+            imageSource = DOMPurify.sanitize(image.attr('data-lazy'));
             imageToLoad = document.createElement('img');
 
             imageToLoad.onload = function () {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "dot-prop": "^5.3.0",
     "jquery": "^3.7.1",
     "netlify-cms": "^2.10.55",
-    "uswds": "^2.14.0"
+    "uswds": "^2.14.0",
+    "dompurify": "^3.2.3"
   },
   "devDependencies": {
     "rimraf": "^3.0.2"
@@ -23,7 +24,7 @@
     "minimist": "1.2.8",
     "remark-parse": ">=10.0.1",
     "mdast-util-to-hast": ">=5.0.0",
-    "trim":">=0.0.3",
+    "trim": ">=0.0.3",
     "tough-cookie": ">=4.1.4",
     "got": ">=11.8.5",
     "trim-newlines": ">=5.0.0",


### PR DESCRIPTION
Fixes [https://github.com/GSA/fpc.gov/security/code-scanning/3](https://github.com/GSA/fpc.gov/security/code-scanning/3)

To fix the problem, we need to ensure that the value of `data-lazy` is properly sanitized before it is used as the `src` attribute of an `img` element. This can be achieved by using a function that validates the URL to ensure it does not contain any malicious content.

The best way to fix this without changing existing functionality is to use a well-known library like `DOMPurify` to sanitize the URL. We will import `DOMPurify` and use it to sanitize the `imageSource` before assigning it to the `src` attribute.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
