### PR TITLE
Fix code scanning alert no. 4: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/slick.js
+++ b/assets/js/slick.js
@@ -1643,12 +1643,21 @@
             $imgsToLoad = $('img[data-lazy]', _.$slider),
             image,
             imageSource,
-            imageToLoad;
+            imageToLoad,
+            isValidUrl;
 
         if ($imgsToLoad.length) {
 
             image = $imgsToLoad.first();
             imageSource = image.attr('data-lazy');
+            isValidUrl = function (url) {
+                try {
+                    new URL(url);
+                    return true;
+                } catch (_) {
+                    return false;
+                }
+            };
             imageToLoad = document.createElement('img');
 
             imageToLoad.onload = function () {
@@ -1695,7 +1704,18 @@
 
             };
 
-            imageToLoad.src = imageSource;
+            if (isValidUrl(imageSource)) {
+                imageToLoad.src = imageSource;
+            } else {
+                image
+                    .removeAttr('data-lazy')
+                    .removeClass('slick-loading')
+                    .addClass('slick-lazyload-error');
+
+                _.$slider.trigger('lazyLoadError', [_, image, imageSource]);
+
+                _.progressiveLazyLoad();
+            }
 
         } else {
 


### PR DESCRIPTION
Fixes [https://github.com/GSA/fpc.gov/security/code-scanning/4](https://github.com/GSA/fpc.gov/security/code-scanning/4)

To fix the problem, we need to ensure that the value extracted from the `data-lazy` attribute is properly sanitized before being used. One way to achieve this is by using a URL validation function to ensure that the `imageSource` is a valid URL. This will prevent any malicious content from being interpreted as HTML.

We will:
1. Add a URL validation function.
2. Use this function to validate `imageSource` before assigning it to `imageToLoad.src`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
