### PR TITLE
Fix code scanning alert no. 5: Unsafe jQuery plugin

### DIFF
--- a/assets/js/magnific-popup.js
+++ b/assets/js/magnific-popup.js
@@ -14,6 +14,26 @@
     }
 }(function($) {
 
+    // Utility function to escape HTML special characters
+    function escapeHtml(text) {
+        return text.replace(/[&<>"']/g, function(match) {
+            switch (match) {
+                case '&':
+                    return '&amp;';
+                case '<':
+                    return '&lt;';
+                case '>':
+                    return '&gt;';
+                case '"':
+                    return '&quot;';
+                case "'":
+                    return '&#039;';
+                default:
+                    return match;
+            }
+        });
+    }
+
     /*>>core*/
     /**
      *
@@ -89,7 +109,7 @@
         },
         _getCloseBtn = function(type) {
             if(type !== _currPopupType || !mfp.currTemplate.closeBtn) {
-                mfp.currTemplate.closeBtn = $( mfp.st.closeMarkup.replace('%title%', mfp.st.tClose ) );
+                mfp.currTemplate.closeBtn = $( mfp.st.closeMarkup.replace('%title%', escapeHtml(mfp.st.tClose)) );
                 _currPopupType = type;
             }
             return mfp.currTemplate.closeBtn;


### PR DESCRIPTION
Fixes [https://github.com/GSA/fpc.gov/security/code-scanning/5](https://github.com/GSA/fpc.gov/security/code-scanning/5)

To fix the problem, we need to ensure that any dynamic HTML construction involving user-provided data is properly sanitized. In this case, we should sanitize the `mfp.st.tClose` value before using it in the `replace` method. We can use a simple utility function to escape any HTML special characters in the `tClose` value to prevent XSS attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
