### PR TITLE
Fix code scanning alert no. 6: Unsafe jQuery plugin

### DIFF
--- a/assets/js/magnific-popup.js
+++ b/assets/js/magnific-popup.js
@@ -353,7 +353,7 @@
             $('html').css(windowStyles);
 
             // add everything to DOM
-            mfp.bgOverlay.add(mfp.wrap).prependTo( mfp.st.prependTo || $(document.body) );
+            mfp.bgOverlay.add(mfp.wrap).prependTo( mfp.st.prependTo ? $.find(mfp.st.prependTo) : $(document.body) );
 
             // Save last focused element
             mfp._lastFocusedEl = document.activeElement;


### PR DESCRIPTION
Fixes [https://github.com/GSA/fpc.gov/security/code-scanning/6](https://github.com/GSA/fpc.gov/security/code-scanning/6)

To fix the problem, we need to ensure that the `prependTo` property of the `options` object is always treated as a CSS selector and not as HTML. This can be achieved by using the `jQuery.find` method instead of directly using the `options.prependTo` property in the jQuery selector. This change will prevent the evaluation of `options.prependTo` as HTML, thereby mitigating the XSS risk.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
