### PR TITLE
Fix code scanning alert no. 9: Unsafe jQuery plugin

### DIFF
--- a/assets/js/magnific-popup.js
+++ b/assets/js/magnific-popup.js
@@ -15,6 +15,13 @@
 }(function($) {
 
     // Utility function to escape HTML special characters
+    function escapeHtmlSpecialChars(str) {
+        return str.replace(/&/g, '&amp;')
+                  .replace(/</g, '&lt;')
+                  .replace(/>/g, '&gt;')
+                  .replace(/"/g, '&quot;')
+                  .replace(/'/g, '&#039;');
+    }
     function escapeHtml(text) {
         return text.replace(/[&<>"']/g, function(match) {
             switch (match) {
@@ -109,7 +116,7 @@
         },
         _getCloseBtn = function(type) {
             if(type !== _currPopupType || !mfp.currTemplate.closeBtn) {
-                mfp.currTemplate.closeBtn = $( mfp.st.closeMarkup.replace('%title%', escapeHtml(mfp.st.tClose)) );
+                mfp.currTemplate.closeBtn = $( escapeHtmlSpecialChars(mfp.st.closeMarkup).replace('%title%', escapeHtml(mfp.st.tClose)) );
                 _currPopupType = type;
             }
             return mfp.currTemplate.closeBtn;


### PR DESCRIPTION
Fixes [https://github.com/GSA/fpc.gov/security/code-scanning/9](https://github.com/GSA/fpc.gov/security/code-scanning/9)

To fix the problem, we need to ensure that any dynamic HTML construction involving user input is properly sanitized. Specifically, we should sanitize `mfp.st.closeMarkup` before using it in the HTML construction on line 112. This can be done by using a utility function to escape HTML special characters in `mfp.st.closeMarkup`.

1. Create a utility function to escape HTML special characters.
2. Use this utility function to sanitize `mfp.st.closeMarkup` before using it in the HTML construction.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
