### PR TITLE
Updated rack 3.1.8 -> 3.1.12 to fix high and medium vulnerabilities r…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,7 @@ GEM
       forwardable-extended (~> 2.6)
     public_suffix (6.0.1)
     racc (1.8.1)
-    rack (3.1.8)
+    rack (3.1.12)
     rainbow (3.1.1)
     rake (13.2.1)
     rb-fsevent (0.11.2)


### PR DESCRIPTION
Updated rack 3.1.8 -> 3.1.12 to fix high and medium vulnerabilities reported by Dependabot. [Preview Link](https://federalist-61b9594e-083a-41f6-89bb-8b418db4ccf9.sites.pages.cloud.gov/preview/gsa/fpc.gov/RITM1317780/)